### PR TITLE
Replace ruby's Matrix with C's CGLM

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ path "." do
 end
 
 gemspec path: "./belts"
+
+gem "rspec"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,11 @@ PATH
       opengl-bindings2 (~> 2.0.0)
     belts_support (0.2.0)
       activesupport (~> 7.0.0)
+      cglm_bindings (~> 0.1.0)
       matrix (~> 0.4.2)
+      zeitwerk (~> 2.4.2)
+    cglm_bindings (0.1.0)
+      ffi (~> 1.15.5)
       zeitwerk (~> 2.4.2)
 
 PATH
@@ -30,6 +34,7 @@ GEM
     ast (2.4.2)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
+    ffi (1.15.5)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     matrix (0.4.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,7 @@ GEM
       tzinfo (~> 2.0)
     ast (2.4.2)
     concurrent-ruby (1.1.10)
+    diff-lcs (1.5.0)
     i18n (1.10.0)
       concurrent-ruby (~> 1.0)
     matrix (0.4.2)
@@ -40,6 +41,19 @@ GEM
     rainbow (3.1.1)
     regexp_parser (2.5.0)
     rexml (3.2.5)
+    rspec (3.11.0)
+      rspec-core (~> 3.11.0)
+      rspec-expectations (~> 3.11.0)
+      rspec-mocks (~> 3.11.0)
+    rspec-core (3.11.0)
+      rspec-support (~> 3.11.0)
+    rspec-expectations (3.11.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-mocks (3.11.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.11.0)
+    rspec-support (3.11.0)
     rubocop (1.29.1)
       parallel (~> 1.10)
       parser (>= 3.1.0.0)
@@ -71,6 +85,7 @@ PLATFORMS
 
 DEPENDENCIES
   belts!
+  rspec
   rubocop-rspec (~> 2.11)
   standard (~> 1.12)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Belts is designed to be easy to pick up and get something out there, ideal for h
 
 # Getting Started
 ## Install
-Install belts globally. Make sure you're running **ruby >= 3.1.2** and have [OpenGL/GLFW](https://www.glfw.org/) installed on your system:
+Install belts globally. Make sure you're running **ruby >= 3.1.2** and have [OpenGL/GLFW](https://www.glfw.org/) and [CGLM](https://github.com/recp/cglm) available in your system:
 ```bash
 gem install belts
 ```

--- a/README.md
+++ b/README.md
@@ -101,9 +101,7 @@ class SpinnerSystem < BeltsEngine::System
     speed = @time.delta_time * 30
 
     spinners.each_with_components do |transform:, **|
-      transform.rotation.x += speed
-      transform.rotation.y += speed
-      transform.rotation.z += speed
+      transform.rotate(speed, speed, speed)
     end
   end
 end

--- a/belts/bin/belts
+++ b/belts/bin/belts
@@ -1,15 +1,3 @@
 #!/usr/bin/env ruby
-require "thor"
-require "belts"
-
-class BeltsCLI < Thor
-  default_task :start
-
-  desc "start", "Starts the game"
-  subcommand "start", Belts::Initializer
-
-  desc "new NAME", "Generate a new project in the current directory with the given NAME"
-  subcommand "new", Belts::Generator
-end
-
-BeltsCLI.start
+require "belts_cli"
+BeltsCli.start

--- a/belts/lib/belts/templates/app/systems/spinner_system.rb.tt
+++ b/belts/lib/belts/templates/app/systems/spinner_system.rb.tt
@@ -6,9 +6,7 @@ class SpinnerSystem < BeltsEngine::System
     speed = @time.delta_time * 30
 
     spinners.each_with_components do |transform:, **|
-      transform.rotation.x += speed
-      transform.rotation.y += speed
-      transform.rotation.z += speed
+      transform.rotate(speed, speed, speed)
     end
   end
 end

--- a/belts/lib/belts_cli.rb
+++ b/belts/lib/belts_cli.rb
@@ -1,0 +1,12 @@
+require "thor"
+require "belts"
+
+class BeltsCli < Thor
+  default_task :start
+
+  desc "start", "Starts the game"
+  subcommand "start", Belts::Initializer
+
+  desc "new NAME", "Generate a new project in the current directory with the given NAME"
+  subcommand "new", Belts::Generator
+end

--- a/belts/spec/belts_cli_spec.rb
+++ b/belts/spec/belts_cli_spec.rb
@@ -1,0 +1,17 @@
+require_relative "../lib/belts_cli"
+
+RSpec.describe BeltsCli do
+  it "generates an executable project" do
+    described_class.start(["new", "new_game"])
+
+    game_id = fork do
+      Dir.chdir("new_game") do
+        described_class.start(["start"])
+      end
+    end
+
+    sleep 3
+
+    expect(Process.kill(15, game_id)).to equal(1)
+  end
+end

--- a/belts_engine/lib/belts_engine.rb
+++ b/belts_engine/lib/belts_engine.rb
@@ -1,6 +1,7 @@
 require "belts_support"
 
 # TODO: Load with zeitwerk
+require_relative "./belts_engine/components/vec2"
 require_relative "./belts_engine/components/vec3"
 require_relative "./belts_engine/components/mat4"
 require_relative "./belts_engine/components/transform"

--- a/belts_engine/lib/belts_engine/components/mat4.rb
+++ b/belts_engine/lib/belts_engine/components/mat4.rb
@@ -39,9 +39,9 @@ class Mat4
       dest_x = Mat4.zero
       dest_y = Mat4.zero
       dest_z = Mat4.zero
-      Glm.glmc_rotate_x(identity.val, vec3.to_a[0] * Math::PI / 180, dest_x.val)
-      Glm.glmc_rotate_y(identity.val, vec3.to_a[1] * Math::PI / 180, dest_y.val)
-      Glm.glmc_rotate_z(identity.val, vec3.to_a[2] * Math::PI / 180, dest_z.val)
+      Glm.glmc_rotate_x(identity.val, vec3.x * Math::PI / 180, dest_x.val)
+      Glm.glmc_rotate_y(identity.val, vec3.y * Math::PI / 180, dest_y.val)
+      Glm.glmc_rotate_z(identity.val, vec3.z * Math::PI / 180, dest_z.val)
 
       dest_x * dest_y * dest_z
     end

--- a/belts_engine/lib/belts_engine/components/mat4.rb
+++ b/belts_engine/lib/belts_engine/components/mat4.rb
@@ -4,23 +4,41 @@ class Mat4
   class << self
     def [](*values) = new(values)
 
+    def identity
+      Mat4[
+        1, 0, 0, 0,
+        0, 1, 0, 0,
+        0, 0, 1, 0,
+        0, 0, 0, 1
+      ]
+    end
+
+    def zero
+      Mat4[
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0,
+        0, 0, 0, 0
+      ]
+    end
+
     def translation(vec3)
-      dest = Mat4.new([])
+      dest = Mat4.identity
       Glm.glmc_translate(dest.val, vec3.val)
       dest
     end
 
     def scale(vec3)
-      dest = Mat4.new([])
+      dest = Mat4.identity
       Glm.glmc_scale(dest.val, vec3.val)
       dest
     end
 
     def rotation(vec3)
-      identity = Mat4.new([])
-      dest_x = Mat4.new([])
-      dest_y = Mat4.new([])
-      dest_z = Mat4.new([])
+      identity = Mat4.identity
+      dest_x = Mat4.zero
+      dest_y = Mat4.zero
+      dest_z = Mat4.zero
       Glm.glmc_rotate_x(identity.val, vec3.to_a[0] * Math::PI / 180, dest_x.val)
       Glm.glmc_rotate_y(identity.val, vec3.to_a[1] * Math::PI / 180, dest_y.val)
       Glm.glmc_rotate_z(identity.val, vec3.to_a[2] * Math::PI / 180, dest_z.val)
@@ -28,9 +46,9 @@ class Mat4
       dest_x * dest_y * dest_z
     end
 
-    def perspective(fovy, aspect, nearVal, farVal)
-      dest = Mat4.new([])
-      Glm.glmc_perspective(fovy, aspect, nearVal, farVal, dest.val)
+    def perspective(fovy, aspect, near_val, far_val)
+      dest = Mat4.identity
+      Glm.glmc_perspective(fovy, aspect, near_val, far_val, dest.val)
       dest
     end
   end
@@ -52,19 +70,19 @@ class Mat4
   end
 
   def *(other)
-    dest = Mat4.new([])
+    dest = Mat4.identity
     Glm.glmc_mat4_mul(@val, other.val, dest.val)
     dest
   end
 
   def transpose
-    dest = Mat4.new([])
+    dest = Mat4.identity
     Glm.glmc_mat4_transpose_to(@val, dest.val)
     dest
   end
 
   def inverse
-    dest = Mat4.new([])
+    dest = Mat4.identity
     Glm.glmc_mat4_inv(@val, dest.val)
     dest
   end

--- a/belts_engine/lib/belts_engine/components/mat4.rb
+++ b/belts_engine/lib/belts_engine/components/mat4.rb
@@ -55,10 +55,7 @@ class Mat4
 
   def initialize(values)
     @val = Glm::Mat4.new
-
-    (0..15).each do |i|
-      @val[:values][i] = values[i] || 0
-    end
+    @val[:values].to_ptr.write_array_of_float(values)
   end
 
   def to_s

--- a/belts_engine/lib/belts_engine/components/mat4.rb
+++ b/belts_engine/lib/belts_engine/components/mat4.rb
@@ -1,88 +1,85 @@
-Mat4 = Struct.new(:m) do
+class Mat4
+  attr_reader :val
+
   class << self
-    def identity = Matrix.identity(4)
+    def [](*values) = new(values)
 
-    def translation(x, y, z)
-      Matrix[
-        [1, 0, 0, x],
-        [0, 1, 0, y],
-        [0, 0, 1, z],
-        [0, 0, 0, 1]
-      ]
+    def translation(vec3)
+      dest = Mat4.new([])
+      Glm.glmc_translate(dest.val, vec3.val)
+      dest
     end
 
-    def rotation(x, y, z)
-      x = x * Math::PI / 180
-      y = y * Math::PI / 180
-      z = z * Math::PI / 180
-
-      rotation_x = Matrix[
-        [1, 0, 0, 0],
-        [0, Math.cos(x), -Math.sin(x), 0],
-        [0, Math.sin(x), Math.cos(x), 0],
-        [0, 0, 0, 1]
-      ]
-
-      rotation_y = Matrix[
-        [Math.cos(y), 0, Math.sin(y), 0],
-        [0, 1, 0, 0],
-        [-Math.sin(y), 0, Math.cos(y), 0],
-        [0, 0, 0, 1]
-      ]
-
-      rotation_z = Matrix[
-        [Math.cos(z), -Math.sin(z), 0, 0],
-        [Math.sin(z), Math.cos(z), 0, 0],
-        [0, 0, 1, 0],
-        [0, 0, 0, 1]
-      ]
-
-      rotation_x * rotation_y * rotation_z
+    def scale(vec3)
+      dest = Mat4.new([])
+      Glm.glmc_scale(dest.val, vec3.val)
+      dest
     end
 
-    def scale(x, y, z)
-      Matrix[
-        [x, 0, 0, 0],
-        [0, y, 0, 0],
-        [0, 0, z, 0],
-        [0, 0, 0, 1]
-      ]
+    def rotation(vec3)
+      identity = Mat4.new([])
+      dest_x = Mat4.new([])
+      dest_y = Mat4.new([])
+      dest_z = Mat4.new([])
+      Glm.glmc_rotate_x(identity.val, vec3.to_a[0] * Math::PI / 180, dest_x.val)
+      Glm.glmc_rotate_y(identity.val, vec3.to_a[1] * Math::PI / 180, dest_y.val)
+      Glm.glmc_rotate_z(identity.val, vec3.to_a[2] * Math::PI / 180, dest_z.val)
+
+      dest_x * dest_y * dest_z
     end
 
-    def perspective(fov, aspect, near, far)
-      fov_rad = fov * Math::PI / 180
-
-      y_scale = 1 / Math.tan(fov_rad)
-      x_scale = y_scale / aspect
-      frustum_length = far - near
-
-      Matrix[
-        [x_scale, 0, 0, 0],
-        [0, y_scale, 0, 0],
-        [0, 0, -(far + near) / frustum_length, -1],
-        [0, 0, 2 * -(far * near) / frustum_length, 0]
-      ].transpose
+    def perspective(fovy, aspect, nearVal, farVal)
+      dest = Mat4.new([])
+      Glm.glmc_perspective(fovy, aspect, nearVal, farVal, dest.val)
+      dest
     end
+  end
 
-    def orthographic(left, right, bottom, top, near, far)
-      scale = scale(2.0 / (right - left), 2.0 / (top - bottom), 2.0 / (far - near))
-      centerer = translation(- (right + left) / (right - left), - (top + bottom) / (top - bottom), (far - near) / 2.0)
-      # inverter = scale(1, 1, -1)
+  def initialize(values)
+    @val = Glm::Mat4.new
 
-      scale * centerer # * inverter
+    (0..15).each do |i|
+      @val[:values][i] = values[i] || 0
     end
+  end
 
-    def look_at(eye, target, up)
-      z_axis = (eye - target).normalize
-      x_axis = up.cross(z_axis).normalize
-      y_axis = z_axis.cross(x_axis)
+  def to_s
+    to_a.join(", ")
+  end
 
-      Matrix[
-        [x_axis[0], x_axis[1], x_axis[2], -x_axis.dot(eye)],
-        [y_axis[0], y_axis[1], y_axis[2], -y_axis.dot(eye)],
-        [z_axis[0], z_axis[1], z_axis[2], -z_axis.dot(eye)],
-        [0, 0, 0, 1]
-      ]
+  def to_a
+    @val[:values].to_a
+  end
+
+  def *(other)
+    dest = Mat4.new([])
+    Glm.glmc_mat4_mul(@val, other.val, dest.val)
+    dest
+  end
+
+  def transpose
+    dest = Mat4.new([])
+    Glm.glmc_mat4_transpose_to(@val, dest.val)
+    dest
+  end
+
+  def inverse
+    dest = Mat4.new([])
+    Glm.glmc_mat4_inv(@val, dest.val)
+    dest
+  end
+
+  def marshal_dump
+    {}.tap do |result|
+      result[:values] = @val[:values].to_a
+    end
+  end
+
+  def marshal_load(serialized_values)
+    @val = Glm::Mat4.new
+
+    (0..15).each do |i|
+      @val[:values][i] = serialized_values[i] || 0
     end
   end
 end

--- a/belts_engine/lib/belts_engine/components/transform.rb
+++ b/belts_engine/lib/belts_engine/components/transform.rb
@@ -1,24 +1,18 @@
-Transform = Struct.new(:position, :rotation, :scale) do
-  def initialize(position: Vec3.zero, rotation: Vec3.zero, scale: Vec3.one) = super(position, rotation, scale)
-
-  def to_matrix
-    Mat4.translation(*position) *
-      Mat4.rotation(*rotation) *
-      Mat4.scale(*scale)
+Transform = Struct.new(:position, :rotation, :scale, :matrix, :flatten_matrix, :flatten_normal_matrix) do
+  def initialize(position: Vec3.zero, rotation: Vec3.zero, scale: Vec3.one)
+    super(position, rotation, scale, nil, nil, nil)
+    set_matrix
   end
 
   def forward
-    matrix = to_matrix
     Vec3[matrix[0, 2], matrix[1, 2], matrix[2, 2]]
   end
 
   def right
-    matrix = to_matrix
     Vec3[matrix[0, 0], matrix[1, 0], matrix[2, 0]]
   end
 
   def up
-    matrix = to_matrix
     Vec3[matrix[0, 1], matrix[1, 1], matrix[2, 1]]
   end
 
@@ -27,4 +21,47 @@ Transform = Struct.new(:position, :rotation, :scale) do
   def left = -right
 
   def down = -up
+
+  def move(x, y, z)
+    self.position = Vec3[
+      position.x + x,
+      position.y + y,
+      position.z + z
+    ]
+  end
+
+  def rotate(x, y, z)
+    self.rotation = Vec3[
+      rotation.x + x,
+      rotation.y + y,
+      rotation.z + z
+    ]
+  end
+
+  def position=(val)
+    self[:position] = val
+    set_matrix
+  end
+
+  def rotation=(val)
+    self[:rotation] = val
+    set_matrix
+  end
+
+  def scale=(val)
+    self[:scale] = val
+    set_matrix
+  end
+
+  private
+
+  def set_matrix
+    self.matrix =
+      Mat4.translation(*position) *
+      Mat4.rotation(*rotation) *
+      Mat4.scale(*scale)
+
+    self.flatten_matrix = matrix.transpose.to_a.flatten.pack("F*")
+    self.flatten_normal_matrix = matrix.inverse.to_a.flatten.pack("F*")
+  end
 end

--- a/belts_engine/lib/belts_engine/components/transform.rb
+++ b/belts_engine/lib/belts_engine/components/transform.rb
@@ -57,9 +57,9 @@ Transform = Struct.new(:position, :rotation, :scale, :matrix, :flatten_matrix, :
 
   def set_matrix
     self.matrix =
-      Mat4.translation(*position) *
-      Mat4.rotation(*rotation) *
-      Mat4.scale(*scale)
+      Mat4.translation(position) *
+      Mat4.rotation(rotation) *
+      Mat4.scale(scale)
 
     self.flatten_matrix = matrix.transpose.to_a.flatten.pack("F*")
     self.flatten_normal_matrix = matrix.inverse.to_a.flatten.pack("F*")

--- a/belts_engine/lib/belts_engine/components/transform.rb
+++ b/belts_engine/lib/belts_engine/components/transform.rb
@@ -1,26 +1,8 @@
-Transform = Struct.new(:position, :rotation, :scale, :matrix, :flatten_matrix, :flatten_normal_matrix) do
+Transform = Struct.new(:position, :rotation, :scale, :matrix) do
   def initialize(position: Vec3.zero, rotation: Vec3.zero, scale: Vec3.one)
-    super(position, rotation, scale, nil, nil, nil)
+    super(position, rotation, scale, nil)
     set_matrix
   end
-
-  def forward
-    Vec3[matrix[0, 2], matrix[1, 2], matrix[2, 2]]
-  end
-
-  def right
-    Vec3[matrix[0, 0], matrix[1, 0], matrix[2, 0]]
-  end
-
-  def up
-    Vec3[matrix[0, 1], matrix[1, 1], matrix[2, 1]]
-  end
-
-  def back = -forward
-
-  def left = -right
-
-  def down = -up
 
   def move(x, y, z)
     self.position = Vec3[
@@ -60,8 +42,5 @@ Transform = Struct.new(:position, :rotation, :scale, :matrix, :flatten_matrix, :
       Mat4.translation(position) *
       Mat4.rotation(rotation) *
       Mat4.scale(scale)
-
-    self.flatten_matrix = matrix.transpose.to_a.flatten.pack("F*")
-    self.flatten_normal_matrix = matrix.inverse.to_a.flatten.pack("F*")
   end
 end

--- a/belts_engine/lib/belts_engine/components/vec2.rb
+++ b/belts_engine/lib/belts_engine/components/vec2.rb
@@ -34,7 +34,11 @@ class Vec2
   end
 
   def to_s
-    @val[:values].to_a.join(", ")
+    to_a.join(", ")
+  end
+
+  def to_a
+    @val[:values].to_a
   end
 
   private

--- a/belts_engine/lib/belts_engine/components/vec2.rb
+++ b/belts_engine/lib/belts_engine/components/vec2.rb
@@ -1,0 +1,65 @@
+class Vec2
+  attr_reader :val
+
+  class << self
+    def [](x = 0, y = 0) = new(x, y)
+
+    def zero = Vec2[0, 0]
+
+    def one = Vec2[1, 1]
+
+    def up = Vec2[0, 1]
+
+    def down = Vec2[0, -1]
+
+    def left = Vec2[-1, 0]
+
+    def right = Vec2[1, 0]
+  end
+
+  def initialize(x = 0, y = 0)
+    @val = Glm::Vec2.new
+    @val[:values][0] = x
+    @val[:values][1] = y
+  end
+
+  def +(other)
+    return vector_sum(other) if other.is_a?(Vec2)
+    scalar_sum(other)
+  end
+
+  def *(other)
+    return vector_mul(other) if other.is_a?(Vec2)
+    scalar_mul(other)
+  end
+
+  def to_s
+    @val[:values].to_a.join(", ")
+  end
+
+  private
+
+  def scalar_sum(scalar)
+    dest = Vec2.new
+    Glm.glmc_vec2_adds(@val, scalar, dest.val)
+    dest
+  end
+
+  def vector_sum(vec2)
+    dest = Vec2.new
+    Glm.glmc_vec2_add(@val, vec2.val, dest.val)
+    dest
+  end
+
+  def scalar_mul(scalar)
+    dest = Vec2.new
+    Glm.glmc_vec2_scale(@val, scalar, dest.val)
+    dest
+  end
+
+  def vector_mul(vec2)
+    dest = Vec2.new
+    Glm.glmc_vec2_mul(@val, vec2.val, dest.val)
+    dest
+  end
+end

--- a/belts_engine/lib/belts_engine/components/vec3.rb
+++ b/belts_engine/lib/belts_engine/components/vec3.rb
@@ -25,7 +25,7 @@ class Vec3
     @val = Glm::Vec3.new
     @val[:values][0] = x
     @val[:values][1] = y
-    @val[:values][2] = y
+    @val[:values][2] = z
   end
 
   def x = @val[:values][0]

--- a/belts_engine/lib/belts_engine/components/vec3.rb
+++ b/belts_engine/lib/belts_engine/components/vec3.rb
@@ -1,6 +1,8 @@
-class Vec3 < Vector
+class Vec3
+  attr_reader :val
+
   class << self
-    def [](x = 0, y = 0, z = 0) = super(x, y, z)
+    def [](x = 0, y = 0, z = 0) = new(x, y, z)
 
     def zero = Vec3[0, 0, 0]
 
@@ -19,21 +21,81 @@ class Vec3 < Vector
     def back = Vec3[0, 0, -1]
   end
 
-  def x = self[0]
-
-  def x=(value)
-    self[0] = value
+  def initialize(x = 0, y = 0, z = 0)
+    @val = Glm::Vec3.new
+    @val[:values][0] = x
+    @val[:values][1] = y
+    @val[:values][2] = y
   end
 
-  def y = self[1]
+  def x = @val[:values][0]
 
-  def y=(value)
-    self[1] = value
+  def y = @val[:values][1]
+
+  def z = @val[:values][2]
+
+  def -@
+    dest = Vec3.new
+    Glm.glmc_vec3_negate_to(@val, dest.val)
+    dest
   end
 
-  def z = self[2]
+  def +(other)
+    return vector_sum(other) if other.is_a?(Vec3)
+    scalar_sum(other)
+  end
 
-  def z=(value)
-    self[2] = value
+  def *(other)
+    return vector_mul(other) if other.is_a?(Vec3)
+    scalar_mul(other)
+  end
+
+  def to_s
+    to_a.join(", ")
+  end
+
+  def to_a
+    @val[:values].to_a
+  end
+
+  def marshal_dump
+    {}.tap do |result|
+      result[:x] = @val[:values][0]
+      result[:y] = @val[:values][1]
+      result[:z] = @val[:values][2]
+    end
+  end
+
+  def marshal_load(serialized_values)
+    @val = Glm::Vec3.new
+    @val[:values][0] = serialized_values[:x]
+    @val[:values][1] = serialized_values[:y]
+    @val[:values][2] = serialized_values[:z]
+  end
+
+  private
+
+  def scalar_sum(scalar)
+    dest = Vec3.new
+    Glm.glmc_vec3_adds(@val, scalar, dest.val)
+    dest
+  end
+
+  def vector_sum(vec3)
+    dest = Vec3.new
+    Glm.glmc_vec3_add(@val, vec3.val, dest.val)
+    dest
+  end
+
+  def scalar_mul(scalar)
+    dest = Vec3.new
+    Glm.glmc_vec3_scale(@val, scalar, dest.val)
+    dest
+  end
+
+  def vector_mul(vec3)
+    dest = Vec3.new
+    Glm.glmc_vec3_mul(@val, vec3.val, dest.val)
+    dest
   end
 end

--- a/belts_engine/lib/belts_engine/tools/input/keyboard.rb
+++ b/belts_engine/lib/belts_engine/tools/input/keyboard.rb
@@ -2,7 +2,7 @@ module BeltsEngine
   module Tools
     class Input
       module Keyboard
-        KEYS = [:w, :a, :s, :d].freeze
+        KEYS = [:w, :a, :s, :d, :space].freeze
 
         def key?(key) = @keyboard_state[key]
 

--- a/belts_opengl/lib/belts_opengl/assets/mesh.rb
+++ b/belts_opengl/lib/belts_opengl/assets/mesh.rb
@@ -56,7 +56,9 @@ module BeltsOpengl::Assets
       GL.BindBuffer(GL::ELEMENT_ARRAY_BUFFER, @ebo)
       GL.BufferData(GL::ELEMENT_ARRAY_BUFFER, @indexes.size * Fiddle::SIZEOF_INT, @indexes.pack("L*"), GL::STATIC_DRAW)
 
+      # Vertices
       GL.VertexAttribPointer(0, 3, GL::FLOAT, GL::FALSE, 6 * Fiddle::SIZEOF_FLOAT, 0)
+      # Normals
       GL.VertexAttribPointer(1, 3, GL::FLOAT, GL::FALSE, 6 * Fiddle::SIZEOF_FLOAT, 3 * Fiddle::SIZEOF_FLOAT)
       GL.EnableVertexAttribArray(0)
       GL.EnableVertexAttribArray(1)

--- a/belts_opengl/lib/belts_opengl/assets/mesh.rb
+++ b/belts_opengl/lib/belts_opengl/assets/mesh.rb
@@ -46,8 +46,6 @@ module BeltsOpengl::Assets
     private
 
     def upload_vertice_data
-      # values_per_vertex = 3
-
       GL.BindVertexArray(@vao)
       GL.BindBuffer(GL::ARRAY_BUFFER, @vbo)
 
@@ -60,6 +58,7 @@ module BeltsOpengl::Assets
       GL.VertexAttribPointer(0, 3, GL::FLOAT, GL::FALSE, 6 * Fiddle::SIZEOF_FLOAT, 0)
       # Normals
       GL.VertexAttribPointer(1, 3, GL::FLOAT, GL::FALSE, 6 * Fiddle::SIZEOF_FLOAT, 3 * Fiddle::SIZEOF_FLOAT)
+
       GL.EnableVertexAttribArray(0)
       GL.EnableVertexAttribArray(1)
 

--- a/belts_opengl/lib/belts_opengl/assets/mesh.rb
+++ b/belts_opengl/lib/belts_opengl/assets/mesh.rb
@@ -34,7 +34,7 @@ module BeltsOpengl::Assets
 
     def draw
       GL.BindVertexArray(@vao)
-      GL.DrawElements(GL::TRIANGLES, @indexes.size, GL::UNSIGNED_INT, @indexes.pack("L*"))
+      GL.DrawElements(GL::TRIANGLES, @indexes.size, GL::UNSIGNED_INT, 0)
     end
 
     def destroy

--- a/belts_opengl/lib/belts_opengl/assets/shaders/base.frag
+++ b/belts_opengl/lib/belts_opengl/assets/shaders/base.frag
@@ -7,9 +7,9 @@ in vec3 normal;
 in vec3 curPosition;
 
 void main() {
-  vec4 objColor = vec4(1, 1, 1, 1);
+  vec4 objColor = vec4(0, 1, 1, 1);
   vec3 lightPosition = vec3(0, 0, -1);
-  vec4 lightColor = vec4(0, 1, 1, 1);
+  vec4 lightColor = vec4(1, 1, 1, 1);
 
   float ambient = 0.2;
   vec3 norm = normalize(normal);

--- a/belts_opengl/lib/belts_opengl/assets/shaders/base.frag
+++ b/belts_opengl/lib/belts_opengl/assets/shaders/base.frag
@@ -2,16 +2,18 @@
 out vec4 FragColor;
 
 in vec3 normal;
-in vec4 curPosition;
+in vec3 curPosition;
 
 void main() {
-  float ambient = 0.2;
-  vec3 lightPosition = vec3(0, 0, -1);
-  vec3 lightDirection = normalize(lightPosition - vec3(curPosition));
-
-  float diffuse = max(dot(normal, lightDirection), 0.0);
   vec4 objColor = vec4(1.0, 0.5, 1, 1);
+  vec3 lightPosition = vec3(0, 0, -10);
   vec4 lightColor = vec4(1, 1, 1, 1);
+  float ambient = 0.0;
+
+  vec3 norm = normalize(normal);
+  vec3 lightDirection = normalize(lightPosition - curPosition);
+
+  float diffuse = max(dot(norm, lightDirection), 0.0f);
 
   FragColor = objColor * lightColor * (diffuse + ambient);
 }

--- a/belts_opengl/lib/belts_opengl/assets/shaders/base.frag
+++ b/belts_opengl/lib/belts_opengl/assets/shaders/base.frag
@@ -1,19 +1,26 @@
 #version 330 core
+uniform vec3 camera_position;
+
 out vec4 FragColor;
 
 in vec3 normal;
 in vec3 curPosition;
 
 void main() {
-  vec4 objColor = vec4(1.0, 0.5, 1, 1);
-  vec3 lightPosition = vec3(0, 0, -10);
-  vec4 lightColor = vec4(1, 1, 1, 1);
-  float ambient = 0.0;
+  vec4 objColor = vec4(1, 1, 1, 1);
+  vec3 lightPosition = vec3(0, 0, -1);
+  vec4 lightColor = vec4(0, 1, 1, 1);
 
+  float ambient = 0.2;
   vec3 norm = normalize(normal);
   vec3 lightDirection = normalize(lightPosition - curPosition);
 
+  float specularLight = 0.5;
   float diffuse = max(dot(norm, lightDirection), 0.0f);
+  vec3 viewDirection = normalize(camera_position - curPosition);
+  vec3 reflectDirection = reflect(-lightDirection, norm);
+  float specAmount = pow(max(dot(viewDirection, reflectDirection), 0.0f), 8);
+  float specular = specAmount * specularLight;
 
-  FragColor = objColor * lightColor * (diffuse + ambient);
+  FragColor = objColor * lightColor * (diffuse + ambient + specular);
 }

--- a/belts_opengl/lib/belts_opengl/assets/shaders/base.vert
+++ b/belts_opengl/lib/belts_opengl/assets/shaders/base.vert
@@ -2,7 +2,7 @@
 layout (location = 0) in vec3 aPosition;
 layout (location = 1) in vec3 aNormal;
 
-uniform mat4 camera_matrix;
+uniform mat4 vp_matrix;
 uniform mat4 model_matrix;
 
 out vec3 normal;
@@ -11,6 +11,6 @@ out vec3 curPosition;
 void main() {
   curPosition = vec3(model_matrix * vec4(aPosition, 1.0));
 
-  gl_Position = camera_matrix * vec4(curPosition, 1.0);
+  gl_Position = vp_matrix * vec4(curPosition, 1.0);
   normal = vec3(model_matrix * vec4(aNormal, 1.0));
 }

--- a/belts_opengl/lib/belts_opengl/assets/shaders/base.vert
+++ b/belts_opengl/lib/belts_opengl/assets/shaders/base.vert
@@ -4,14 +4,13 @@ layout (location = 1) in vec3 aNormal;
 
 uniform mat4 camera_matrix;
 uniform mat4 model_matrix;
-uniform mat4 normal_matrix;
 
 out vec3 normal;
-out vec4 curPosition;
+out vec3 curPosition;
 
 void main() {
-  normal = mat3(normal_matrix) * aNormal;
-  curPosition = model_matrix * vec4(aPosition, 1.0);
+  curPosition = vec3(model_matrix * vec4(aPosition, 1.0));
 
-  gl_Position = camera_matrix * curPosition;
+  gl_Position = camera_matrix * vec4(curPosition, 1.0);
+  normal = vec3(model_matrix * vec4(aNormal, 1.0));
 }

--- a/belts_opengl/lib/belts_opengl/input_manager.rb
+++ b/belts_opengl/lib/belts_opengl/input_manager.rb
@@ -4,7 +4,8 @@ module BeltsOpengl
       GLFW::KEY_W => :w,
       GLFW::KEY_A => :a,
       GLFW::KEY_S => :s,
-      GLFW::KEY_D => :d
+      GLFW::KEY_D => :d,
+      GLFW::KEY_SPACE => :space
     }
 
     BUTTON_MAP = {

--- a/belts_opengl/lib/belts_opengl/input_manager.rb
+++ b/belts_opengl/lib/belts_opengl/input_manager.rb
@@ -30,7 +30,7 @@ module BeltsOpengl
 
     private
 
-    # NOTE: registering the callback with memoization because the gem has an
+    # NOTE: registering the callbacks with memoization because the gem has an
     # issue keeping reference to a local variable or method call, resulting
     # in a segfault
     def key_callback

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -45,12 +45,8 @@ module BeltsOpengl
 
     def camera_matrix
       cameras.each_with_components do |transform:, camera_data:, **|
-        # view_matrix = Mat4.look_at(transform.position, transform.position + transform.forward, transform.up)
-        view_matrix = Mat4.rotation(*-transform.rotation) * Mat4.scale(1, 1, -1) * Mat4.translation(*-transform.position)
+        view_matrix = Mat4.rotation(-transform.rotation) * Mat4.scale(Vec3[1, 1, -1]) * Mat4.translation(-transform.position)
         proj_matrix = Mat4.perspective(45, @game.window.ratio, 0.1, 100)
-
-        # ortho_size = 5
-        # orth_matrix = Mat4.orthographic(-ortho_size * @game.window.ratio, ortho_size * @game.window.ratio, -ortho_size, ortho_size, 0, 10)
 
         return (proj_matrix * view_matrix)
       end

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -25,17 +25,14 @@ module BeltsOpengl
       flatten_camera_matrix = camera_matrix.transpose.to_a.flatten.pack("F*")
 
       objects.each_with_components do |transform:, render_data:, **|
-        model_matrix = transform.to_matrix
-        normal_matrix = model_matrix.inverse.transpose
-
         camera_loc = GL.GetUniformLocation(default_shader, "camera_matrix")
         GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, flatten_camera_matrix)
 
         model_loc = GL.GetUniformLocation(default_shader, "model_matrix")
-        GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, model_matrix.transpose.to_a.flatten.pack("F*"))
+        GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, transform.flatten_matrix)
 
         normal_loc = GL.GetUniformLocation(default_shader, "normal_matrix")
-        GL.UniformMatrix4fv(normal_loc, 1, GL::FALSE, normal_matrix.transpose.to_a.flatten.pack("F*"))
+        GL.UniformMatrix4fv(normal_loc, 1, GL::FALSE, transform.flatten_normal_matrix)
 
         mesh = @game.asset_manager.get_mesh(render_data.type)
         mesh.draw

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -24,7 +24,7 @@ module BeltsOpengl
     def render_entities
       camera_matrix = nil
 
-      cameras.each_with_components do |transform:, _camera_data:, **|
+      cameras.each_with_components do |transform:, camera_data:, **|
         # view_matrix = Mat4.look_at(transform.position, transform.position + transform.forward, transform.up)
         view_matrix = Mat4.rotation(*-transform.rotation) * Mat4.scale(1, 1, -1) * Mat4.translation(*-transform.position)
         proj_matrix = Mat4.perspective(45, @game.window.ratio, 0.1, 100)

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -16,19 +16,34 @@ module BeltsOpengl
       GL.Clear(GL::COLOR_BUFFER_BIT | GL::DEPTH_BUFFER_BIT)
       GL.UseProgram(default_shader)
 
-      render_entities
+      upload_camera_data
+      upload_object_data
     end
 
     private
 
-    def render_entities
-      camera_matrix_addr = camera_matrix.val.to_ptr.address
+    def upload_camera_data
+      cameras.each_with_components do |transform:, camera_data:, **|
+        invert_z_axis_matrix = Mat4.scale(Vec3[1, 1, -1])
 
+        view_matrix =
+          invert_z_axis_matrix *
+          Mat4.rotation(-transform.rotation) *
+          Mat4.translation(-transform.position)
+
+        proj_matrix = Mat4.perspective(45.0 * Math::PI / 180, @game.window.ratio, 0.1, 100)
+
+        vp_matrix_loc = GL.GetUniformLocation(default_shader, "vp_matrix")
+        GL.UniformMatrix4fv(vp_matrix_loc, 1, GL::FALSE, (proj_matrix * view_matrix).val.to_ptr.address)
+
+        camera_pos_loc = GL.GetUniformLocation(default_shader, "camera_position")
+        GL.Uniform3f(camera_pos_loc, 1, GL::FALSE, transform.position.val.to_ptr.address)
+      end
+    end
+
+    def upload_object_data
       objects.each_with_components do |transform:, render_data:, **|
         model_matrix_addr = transform.matrix.val.to_ptr.address
-
-        camera_loc = GL.GetUniformLocation(default_shader, "camera_matrix")
-        GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, camera_matrix_addr)
 
         model_loc = GL.GetUniformLocation(default_shader, "model_matrix")
         GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, model_matrix_addr)
@@ -40,21 +55,6 @@ module BeltsOpengl
 
     def default_shader
       @game.asset_manager.get_shader(:default)
-    end
-
-    def camera_matrix
-      cameras.each_with_components do |transform:, camera_data:, **|
-        invert_z_axis_matrix = Mat4.scale(Vec3[1, 1, -1])
-
-        view_matrix =
-          invert_z_axis_matrix *
-          Mat4.rotation(-transform.rotation) *
-          Mat4.translation(-transform.position)
-
-        proj_matrix = Mat4.perspective(45.0 * Math::PI / 180, @game.window.ratio, 0.1, 100)
-
-        return proj_matrix * view_matrix
-      end
     end
   end
 end

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -26,16 +26,12 @@ module BeltsOpengl
 
       objects.each_with_components do |transform:, render_data:, **|
         model_matrix_addr = transform.matrix.val.to_ptr.address
-        normal_matrix_addr = transform.matrix.inverse.val.to_ptr.address
 
         camera_loc = GL.GetUniformLocation(default_shader, "camera_matrix")
         GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, camera_matrix_addr)
 
         model_loc = GL.GetUniformLocation(default_shader, "model_matrix")
         GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, model_matrix_addr)
-
-        normal_loc = GL.GetUniformLocation(default_shader, "normal_matrix")
-        GL.UniformMatrix4fv(normal_loc, 1, GL::FALSE, normal_matrix_addr)
 
         mesh = @game.asset_manager.get_mesh(render_data.type)
         mesh.draw

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -22,25 +22,14 @@ module BeltsOpengl
     private
 
     def render_entities
-      camera_matrix = nil
-
-      cameras.each_with_components do |transform:, camera_data:, **|
-        # view_matrix = Mat4.look_at(transform.position, transform.position + transform.forward, transform.up)
-        view_matrix = Mat4.rotation(*-transform.rotation) * Mat4.scale(1, 1, -1) * Mat4.translation(*-transform.position)
-        proj_matrix = Mat4.perspective(45, @game.window.ratio, 0.1, 100)
-
-        # ortho_size = 5
-        # orth_matrix = Mat4.orthographic(-ortho_size * @game.window.ratio, ortho_size * @game.window.ratio, -ortho_size, ortho_size, 0, 10)
-
-        camera_matrix = (proj_matrix * view_matrix)
-      end
+      flatten_camera_matrix = camera_matrix.transpose.to_a.flatten.pack("F*")
 
       objects.each_with_components do |transform:, render_data:, **|
         model_matrix = transform.to_matrix
         normal_matrix = model_matrix.inverse.transpose
 
         camera_loc = GL.GetUniformLocation(default_shader, "camera_matrix")
-        GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, camera_matrix.transpose.to_a.flatten.pack("F*"))
+        GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, flatten_camera_matrix)
 
         model_loc = GL.GetUniformLocation(default_shader, "model_matrix")
         GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, model_matrix.transpose.to_a.flatten.pack("F*"))
@@ -55,6 +44,19 @@ module BeltsOpengl
 
     def default_shader
       @game.asset_manager.get_shader(:default)
+    end
+
+    def camera_matrix
+      cameras.each_with_components do |transform:, camera_data:, **|
+        # view_matrix = Mat4.look_at(transform.position, transform.position + transform.forward, transform.up)
+        view_matrix = Mat4.rotation(*-transform.rotation) * Mat4.scale(1, 1, -1) * Mat4.translation(*-transform.position)
+        proj_matrix = Mat4.perspective(45, @game.window.ratio, 0.1, 100)
+
+        # ortho_size = 5
+        # orth_matrix = Mat4.orthographic(-ortho_size * @game.window.ratio, ortho_size * @game.window.ratio, -ortho_size, ortho_size, 0, 10)
+
+        return (proj_matrix * view_matrix)
+      end
     end
   end
 end

--- a/belts_opengl/lib/belts_opengl/systems/render_system.rb
+++ b/belts_opengl/lib/belts_opengl/systems/render_system.rb
@@ -22,20 +22,20 @@ module BeltsOpengl
     private
 
     def render_entities
-      flatten_camera_matrix = camera_matrix.val.to_ptr.address
+      camera_matrix_addr = camera_matrix.val.to_ptr.address
 
       objects.each_with_components do |transform:, render_data:, **|
-        flatten_model_matrix = transform.matrix.val.to_ptr.address
-        flatten_normal_matrix = transform.matrix.inverse.val.to_ptr.address
+        model_matrix_addr = transform.matrix.val.to_ptr.address
+        normal_matrix_addr = transform.matrix.inverse.val.to_ptr.address
 
         camera_loc = GL.GetUniformLocation(default_shader, "camera_matrix")
-        GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, flatten_camera_matrix)
+        GL.UniformMatrix4fv(camera_loc, 1, GL::FALSE, camera_matrix_addr)
 
         model_loc = GL.GetUniformLocation(default_shader, "model_matrix")
-        GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, flatten_model_matrix)
+        GL.UniformMatrix4fv(model_loc, 1, GL::FALSE, model_matrix_addr)
 
         normal_loc = GL.GetUniformLocation(default_shader, "normal_matrix")
-        GL.UniformMatrix4fv(normal_loc, 1, GL::FALSE, flatten_normal_matrix)
+        GL.UniformMatrix4fv(normal_loc, 1, GL::FALSE, normal_matrix_addr)
 
         mesh = @game.asset_manager.get_mesh(render_data.type)
         mesh.draw

--- a/belts_support/belts_support.gemspec
+++ b/belts_support/belts_support.gemspec
@@ -12,6 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 3.1.2"
   s.add_dependency "activesupport", "~> 7.0.0"
+  s.add_dependency "cglm_bindings", "~> 0.1.0"
   s.add_dependency "matrix", "~> 0.4.2"
   s.add_dependency "zeitwerk", "~> 2.4.2"
 end

--- a/belts_support/lib/belts_support.rb
+++ b/belts_support/lib/belts_support.rb
@@ -1,5 +1,6 @@
 require "active_support/inflector"
 require "active_support/core_ext/module/delegation"
+require "cglm_bindings"
 require "matrix"
 require "zeitwerk"
 

--- a/cglm_bindings/cglm_bindings.gemspec
+++ b/cglm_bindings/cglm_bindings.gemspec
@@ -1,0 +1,13 @@
+Gem::Specification.new do |s|
+  s.name = "cglm_bindings"
+  s.version = "0.1.0"
+  s.summary = "Ruby bindings for CGLM, a highly optimized math library for C"
+  s.author = "Guilherme Graca"
+  s.homepage = "https://github.com/ggraca/cglm-bindings"
+  s.license = "MIT"
+
+  s.files = Dir.glob("lib/**/*")
+
+  s.add_dependency "ffi", "~> 1.15.5"
+  s.add_dependency "zeitwerk", "~> 2.4.2"
+end

--- a/cglm_bindings/lib/cglm_bindings.rb
+++ b/cglm_bindings/lib/cglm_bindings.rb
@@ -25,6 +25,7 @@ module Glm
   attach_function :glmc_mat4_inv, [Glm::Mat4.by_ref, Glm::Mat4.by_ref], :void
 
   attach_function :glmc_translate, [Glm::Mat4.by_ref, Glm::Vec3.by_ref], :void
+  attach_function :glmc_translate_to, [Glm::Mat4.by_ref, Glm::Vec3.by_ref, Glm::Mat4.by_ref], :void
   attach_function :glmc_scale, [Glm::Mat4.by_ref, Glm::Vec3.by_ref], :void
   attach_function :glmc_rotate_x, [Glm::Mat4.by_ref, :float, Glm::Mat4.by_ref], :void
   attach_function :glmc_rotate_y, [Glm::Mat4.by_ref, :float, Glm::Mat4.by_ref], :void

--- a/cglm_bindings/lib/cglm_bindings.rb
+++ b/cglm_bindings/lib/cglm_bindings.rb
@@ -19,4 +19,16 @@ module Glm
   attach_function :glmc_vec3_add, [Glm::Vec3.by_ref, Glm::Vec3.by_ref, Glm::Vec3.by_ref], :void
   attach_function :glmc_vec3_scale, [Glm::Vec3.by_ref, :float, Glm::Vec3.by_ref], :void
   attach_function :glmc_vec3_mul, [Glm::Vec3.by_ref, Glm::Vec3.by_ref, Glm::Vec3.by_ref], :void
+
+  attach_function :glmc_mat4_mul, [Glm::Mat4.by_ref, Glm::Mat4.by_ref, Glm::Mat4.by_ref], :void
+  attach_function :glmc_mat4_transpose_to, [Glm::Mat4.by_ref, Glm::Mat4.by_ref], :void
+  attach_function :glmc_mat4_inv, [Glm::Mat4.by_ref, Glm::Mat4.by_ref], :void
+
+  attach_function :glmc_translate, [Glm::Mat4.by_ref, Glm::Vec3.by_ref], :void
+  attach_function :glmc_scale, [Glm::Mat4.by_ref, Glm::Vec3.by_ref], :void
+  attach_function :glmc_rotate_x, [Glm::Mat4.by_ref, :float, Glm::Mat4.by_ref], :void
+  attach_function :glmc_rotate_y, [Glm::Mat4.by_ref, :float, Glm::Mat4.by_ref], :void
+  attach_function :glmc_rotate_z, [Glm::Mat4.by_ref, :float, Glm::Mat4.by_ref], :void
+
+  attach_function :glmc_perspective, [:float, :float, :float, :float, Glm::Mat4.by_ref], :void
 end

--- a/cglm_bindings/lib/cglm_bindings.rb
+++ b/cglm_bindings/lib/cglm_bindings.rb
@@ -1,0 +1,17 @@
+require "ffi"
+require "zeitwerk"
+
+loader = Zeitwerk::Loader.for_gem
+loader.setup
+
+module Glm
+  extend FFI::Library
+  ffi_lib :libcglm
+
+  attach_function :glmc_vec2_one, [Glm::Vec2.by_ref], :void
+  attach_function :glmc_vec2_dot, [Glm::Vec2.by_ref, Glm::Vec2.by_ref], :float
+  attach_function :glmc_vec2_adds, [Glm::Vec2.by_ref, :float, Glm::Vec2.by_ref], :void
+  attach_function :glmc_vec2_add, [Glm::Vec2.by_ref, Glm::Vec2.by_ref, Glm::Vec2.by_ref], :void
+  attach_function :glmc_vec2_scale, [Glm::Vec2.by_ref, :float, Glm::Vec2.by_ref], :void
+  attach_function :glmc_vec2_mul, [Glm::Vec2.by_ref, Glm::Vec2.by_ref, Glm::Vec2.by_ref], :void
+end

--- a/cglm_bindings/lib/cglm_bindings.rb
+++ b/cglm_bindings/lib/cglm_bindings.rb
@@ -8,10 +8,15 @@ module Glm
   extend FFI::Library
   ffi_lib :libcglm
 
-  attach_function :glmc_vec2_one, [Glm::Vec2.by_ref], :void
-  attach_function :glmc_vec2_dot, [Glm::Vec2.by_ref, Glm::Vec2.by_ref], :float
   attach_function :glmc_vec2_adds, [Glm::Vec2.by_ref, :float, Glm::Vec2.by_ref], :void
   attach_function :glmc_vec2_add, [Glm::Vec2.by_ref, Glm::Vec2.by_ref, Glm::Vec2.by_ref], :void
   attach_function :glmc_vec2_scale, [Glm::Vec2.by_ref, :float, Glm::Vec2.by_ref], :void
   attach_function :glmc_vec2_mul, [Glm::Vec2.by_ref, Glm::Vec2.by_ref, Glm::Vec2.by_ref], :void
+
+  attach_function :glmc_vec3_negate, [Glm::Vec3.by_ref], :void
+  attach_function :glmc_vec3_negate_to, [Glm::Vec3.by_ref, Glm::Vec3.by_ref], :void
+  attach_function :glmc_vec3_adds, [Glm::Vec3.by_ref, :float, Glm::Vec3.by_ref], :void
+  attach_function :glmc_vec3_add, [Glm::Vec3.by_ref, Glm::Vec3.by_ref, Glm::Vec3.by_ref], :void
+  attach_function :glmc_vec3_scale, [Glm::Vec3.by_ref, :float, Glm::Vec3.by_ref], :void
+  attach_function :glmc_vec3_mul, [Glm::Vec3.by_ref, Glm::Vec3.by_ref, Glm::Vec3.by_ref], :void
 end

--- a/cglm_bindings/lib/glm/mat4.rb
+++ b/cglm_bindings/lib/glm/mat4.rb
@@ -1,0 +1,5 @@
+module Glm
+  class Mat4 < FFI::Struct
+    layout :values, [:float, 16]
+  end
+end

--- a/cglm_bindings/lib/glm/vec2.rb
+++ b/cglm_bindings/lib/glm/vec2.rb
@@ -1,0 +1,5 @@
+module Glm
+  class Vec2 < FFI::Struct
+    layout :values, [:float, 2]
+  end
+end

--- a/cglm_bindings/lib/glm/vec3.rb
+++ b/cglm_bindings/lib/glm/vec3.rb
@@ -1,0 +1,5 @@
+module Glm
+  class Vec3 < FFI::Struct
+    layout :values, [:float, 3]
+  end
+end


### PR DESCRIPTION
The matrix gem is not efficient enough for games. This PR replaces it with a C implementation of GLM, the most popular lib for 3d math.

Observations:
- We're using [FFI](https://github.com/ffi/ffi) instead of [fiddle](https://github.com/ruby/fiddle) for C bindings. C++ is not yet fully supported, that's why we went with [CGLM](https://github.com/recp/cglm) instead of the original lib.
- I haven't yet figured out how to build or how to include the `.so` / `.dll` files during the installation. For now, users will have to handle this themselves.
- In a stress test scene, with 400 objects, this improved fps from ~15 to ~32. The next bottleneck seems to be rotations (which might be able to be fixed by using quaternions, included in this lib)